### PR TITLE
Mark fields correctly as nullable

### DIFF
--- a/src/__fixture__/tablesMeta.json.ts
+++ b/src/__fixture__/tablesMeta.json.ts
@@ -1,0 +1,68 @@
+import type {BaseSchema} from '../getBaseSchema';
+
+/**
+ * Dump of an airtable table containing all field types.
+ */
+export const tablesMeta = {
+	tables: [{
+		id: 'tbluntrYUZ5bTz7YP', name: 'Table 1', primaryFieldId: 'fld7fNzf6ElsnsiXP', fields: [{type: 'singleLineText', id: 'fld7fNzf6ElsnsiXP', name: 'Single Line Text'},
+			{type: 'singleCollaborator', id: 'fldzS7AY8z7fnPA2k', name: 'User'},
+			{
+				type: 'singleSelect', options: {choices: [{id: 'sel8rlr1irDiJymSd', name: 'Todo', color: 'redLight2'}, {id: 'sel7fRrgENSSM1Kwx', name: 'In progress', color: 'yellowLight2'}, {id: 'selMu3Gxu6YDW89st', name: 'Done', color: 'greenLight2'}]}, id: 'fldtZ94euYOEgLIKx', name: 'Single Select',
+			},
+			{
+				type: 'multipleAttachments', options: {isReversed: false}, id: 'fldZXvZHFB1kQ8aO4', name: 'Attachments',
+			},
+			{
+				type: 'aiText', options: {referencedFieldIds: ['fldZXvZHFB1kQ8aO4'], prompt: ['', {field: {fieldId: 'fldZXvZHFB1kQ8aO4'}}]}, id: 'fldIs4nyExgOYguEi', name: 'AI Text', description: '',
+			},
+			{type: 'multilineText', id: 'fldFtEQouCSxqW6sL', name: 'Long Text'},
+			{
+				type: 'checkbox', options: {icon: 'check', color: 'greenBright'}, id: 'flddE4RG6Mlugqo8X', name: 'Checkbox',
+			},
+			{
+				type: 'multipleSelects', options: {choices: [{id: 'selcufYWsGwXvoe5K', name: 'A', color: 'blueLight2'}, {id: 'seldJM3V2vfY1MwId', name: 'B', color: 'cyanLight2'}]}, id: 'fldFWelqOO9koF8fM', name: 'Multiple Select',
+			},
+			{
+				type: 'date', options: {dateFormat: {name: 'local', format: 'l'}}, id: 'fldAUPoAJ67TUwaVS', name: 'Date',
+			},
+			{
+				type: 'dateTime', options: {dateFormat: {name: 'local', format: 'l'}, timeFormat: {name: '12hour', format: 'h:mma'}, timeZone: 'client'}, id: 'fldXCnBVRZ4HO4KIh', name: 'Datetime',
+			},
+			{type: 'phoneNumber', id: 'fldo5kOL07o835nyt', name: 'Phone Number'},
+			{type: 'email', id: 'fldkmeNd7ZAGTS0nA', name: 'Email'},
+			{type: 'url', id: 'fldAyWIcU6mOwCZl2', name: 'URL'},
+			{
+				type: 'number', options: {precision: 1}, id: 'fldN9DNkpCQ6IXH5C', name: 'Number',
+			},
+			{
+				type: 'currency', options: {precision: 2, symbol: '$'}, id: 'fldcaKq3Hq6Rr1R53', name: 'Currency',
+			},
+			{
+				type: 'percent', options: {precision: 0}, id: 'fldsKAqUJjKv5hlH1', name: 'Percent',
+			},
+			{
+				type: 'duration', options: {durationFormat: 'h:mm'}, id: 'fldMH1inCgmp6KD8q', name: 'Duration',
+			},
+			{
+				type: 'rating', options: {icon: 'star', max: 5, color: 'yellowBright'}, id: 'fldFZtTmcTm1Fxu4B', name: 'Rating',
+			},
+			{
+				type: 'formula', options: {
+					isValid: true, formula: '{fld7fNzf6ElsnsiXP}', referencedFieldIds: ['fld7fNzf6ElsnsiXP'], result: {type: 'singleLineText'},
+				}, id: 'fldmYyrXlqiUpBu0C', name: 'Formula',
+			},
+			{
+				type: 'createdTime', options: {result: {type: 'dateTime', options: {dateFormat: {name: 'local', format: 'l'}, timeFormat: {name: '12hour', format: 'h:mma'}, timeZone: 'client'}}}, id: 'fldOJHvKq8rrIYV90', name: 'Created',
+			},
+			{
+				type: 'lastModifiedTime', options: {isValid: true, referencedFieldIds: [], result: {type: 'dateTime', options: {dateFormat: {name: 'local', format: 'l'}, timeFormat: {name: '12hour', format: 'h:mma'}, timeZone: 'client'}}}, id: 'fldH5xY5CV0Q4g5fY', name: 'Last Modified',
+			},
+			{type: 'lastModifiedBy', id: 'fld6W3h7dnVJhIni9', name: 'Last Modified By'},
+			{type: 'createdBy', id: 'fldDcRoVGJXIhVSAi', name: 'Created By'},
+			{type: 'autoNumber', id: 'fldGM8wIYk3G8WMiE', name: 'ID'},
+			{type: 'barcode', id: 'fldMPs1eLH8X5bWeS', name: 'Barcode'},
+			{type: 'button', id: 'fldAG3LTbJRwQVEvS', name: 'Button'}],
+	}],
+} satisfies {tables: BaseSchema};
+

--- a/src/getBaseSchema.ts
+++ b/src/getBaseSchema.ts
@@ -12,6 +12,7 @@ export type FieldSchema = {
 export type BaseSchema = {
 	id: string;
 	name: string;
+	primaryFieldId?: string;
 	description?: string;
 	fields: FieldSchema[];
 }[];

--- a/src/jsTypeForAirtableType.test.ts
+++ b/src/jsTypeForAirtableType.test.ts
@@ -1,0 +1,90 @@
+import {jsTypeForAirtableType} from './jsTypeForAirtableType';
+import {tablesMeta} from './__fixture__/tablesMeta.json';
+import {expect, it, describe} from 'vitest';
+
+describe('jsTypeForAirtableType', () => {
+	const table = tablesMeta.tables[0]!;
+
+	it('converts text-based fields to string | null', () => {
+		const singleLineText = table.fields.find((f) => f.type === 'singleLineText')!;
+		const multilineText = table.fields.find((f) => f.type === 'multilineText')!;
+		const email = table.fields.find((f) => f.type === 'email')!;
+		const url = table.fields.find((f) => f.type === 'url')!;
+		const phoneNumber = table.fields.find((f) => f.type === 'phoneNumber')!;
+		const singleSelect = table.fields.find((f) => f.type === 'singleSelect')!;
+		const singleCollaborator = table.fields.find((f) => f.type === 'singleCollaborator')!;
+		const barcode = table.fields.find((f) => f.type === 'barcode')!;
+		const button = table.fields.find((f) => f.type === 'button')!;
+		const createdBy = table.fields.find((f) => f.type === 'createdBy')!;
+		const lastModifiedBy = table.fields.find((f) => f.type === 'lastModifiedBy')!;
+
+		expect(jsTypeForAirtableType(singleLineText)).toBe('string | null');
+		expect(jsTypeForAirtableType(multilineText)).toBe('string | null');
+		expect(jsTypeForAirtableType(email)).toBe('string | null');
+		expect(jsTypeForAirtableType(url)).toBe('string | null');
+		expect(jsTypeForAirtableType(phoneNumber)).toBe('string | null');
+		expect(jsTypeForAirtableType(singleSelect)).toBe('string | null');
+		expect(jsTypeForAirtableType(singleCollaborator)).toBe('string | null');
+		expect(jsTypeForAirtableType(barcode)).toBe('string | null');
+		expect(jsTypeForAirtableType(button)).toBe('string | null');
+
+		expect(jsTypeForAirtableType(createdBy)).toBe('string');
+		expect(jsTypeForAirtableType(lastModifiedBy)).toBe('string | null');
+	});
+
+	it('converts multiple-value fields to string[]', () => {
+		const multipleAttachments = table.fields.find((f) => f.type === 'multipleAttachments')!;
+		const multipleSelects = table.fields.find((f) => f.type === 'multipleSelects')!;
+
+		expect(jsTypeForAirtableType(multipleAttachments)).toBe('string[]');
+		expect(jsTypeForAirtableType(multipleSelects)).toBe('string[]');
+	});
+
+	it('converts numeric fields to number', () => {
+		const number = table.fields.find((f) => f.type === 'number')!;
+		const currency = table.fields.find((f) => f.type === 'currency')!;
+		const percent = table.fields.find((f) => f.type === 'percent')!;
+		const duration = table.fields.find((f) => f.type === 'duration')!;
+		const rating = table.fields.find((f) => f.type === 'rating')!;
+		const autoNumber = table.fields.find((f) => f.type === 'autoNumber')!;
+
+		expect(jsTypeForAirtableType(number)).toBe('number | null');
+		expect(jsTypeForAirtableType(currency)).toBe('number | null');
+		expect(jsTypeForAirtableType(percent)).toBe('number | null');
+		expect(jsTypeForAirtableType(duration)).toBe('number | null');
+		expect(jsTypeForAirtableType(rating)).toBe('number | null');
+		expect(jsTypeForAirtableType(autoNumber)).toBe('number');
+	});
+
+	it('converts date/time fields to number (Unix timestamp)', () => {
+		const date = table.fields.find((f) => f.type === 'date')!;
+		const dateTime = table.fields.find((f) => f.type === 'dateTime')!;
+		const createdTime = table.fields.find((f) => f.type === 'createdTime')!;
+		const lastModifiedTime = table.fields.find((f) => f.type === 'lastModifiedTime')!;
+
+		expect(jsTypeForAirtableType(date)).toBe('number | null');
+		expect(jsTypeForAirtableType(dateTime)).toBe('number | null');
+		expect(jsTypeForAirtableType(createdTime)).toBe('number');
+		expect(jsTypeForAirtableType(lastModifiedTime)).toBe('number | null');
+	});
+
+	it('converts checkbox to boolean', () => {
+		const checkbox = table.fields.find((f) => f.type === 'checkbox')!;
+		expect(jsTypeForAirtableType(checkbox)).toBe('boolean');
+	});
+
+	it('handles formula fields with result type', () => {
+		const formula = table.fields.find((f) => f.type === 'formula')!;
+		expect(jsTypeForAirtableType(formula)).toBe('string | null');
+	});
+
+	it('throws error for invalid formula field', () => {
+		const invalidFormula = {
+			type: 'formula',
+			id: 'invalid',
+			options: {}, // Missing result property
+		};
+
+		expect(() => jsTypeForAirtableType(invalidFormula as any)).toThrow('Invalid formula field (no options.result): invalid');
+	});
+});

--- a/src/jsTypeForAirtableType.ts
+++ b/src/jsTypeForAirtableType.ts
@@ -17,10 +17,11 @@ export const jsTypeForAirtableType = (field: FieldSchema): string | null => {
 		case 'externalSyncSource':
 		case 'aiText':
 		case 'singleCollaborator':
-		case 'createdBy':
 		case 'lastModifiedBy':
 		case 'barcode':
 		case 'button':
+			return 'string | null';
+		case 'createdBy':
 			return 'string';
 		case 'multipleAttachments':
 		case 'multipleCollaborators':
@@ -32,13 +33,15 @@ export const jsTypeForAirtableType = (field: FieldSchema): string | null => {
 		case 'duration':
 		case 'currency':
 		case 'percent':
+			return 'number | null';
 		case 'count':
 		case 'autoNumber':
 			return 'number';
 		case 'date':
 		case 'dateTime':
-		case 'createdTime':
 		case 'lastModifiedTime':
+			return 'number | null'; // Unix timestamp in seconds
+		case 'createdTime':
 			return 'number'; // Unix timestamp in seconds
 		case 'checkbox':
 			return 'boolean';
@@ -55,6 +58,10 @@ export const jsTypeForAirtableType = (field: FieldSchema): string | null => {
 				const innerType = jsTypeForAirtableType(field.options.result as FieldSchema);
 				if (innerType === null) {
 					return null;
+				}
+
+				if (innerType.includes('null')) {
+					return innerType;
 				}
 
 				return `${innerType} | null`;


### PR DESCRIPTION
Fixes #20 

Changing the types generated for different fields. 

Went through the docs to better understand which fields are nullable by design from Airtables perspective, i believe this is accurate. I also created a table with a column for each field type, and addded a test for them. 

I tested that running `airtable-ts` with the schema produced does not produce any runtime errors on rows where all fields are left empty (so just adding a new row in the base), whereas the schema produced before this pr produces runtime errors  