### PR TITLE
Fix multipleLookupValues generating incorrect TypeScript type

### DIFF
--- a/src/__fixture__/tablesMeta.json.ts
+++ b/src/__fixture__/tablesMeta.json.ts
@@ -62,7 +62,22 @@ export const tablesMeta = {
 			{type: 'createdBy', id: 'fldDcRoVGJXIhVSAi', name: 'Created By'},
 			{type: 'autoNumber', id: 'fldGM8wIYk3G8WMiE', name: 'ID'},
 			{type: 'barcode', id: 'fldMPs1eLH8X5bWeS', name: 'Barcode'},
-			{type: 'button', id: 'fldAG3LTbJRwQVEvS', name: 'Button'}],
+			{type: 'button', id: 'fldAG3LTbJRwQVEvS', name: 'Button'},
+			{
+				type: 'multipleLookupValues', options: {
+					isValid: true, recordLinkFieldId: 'fldLinked', fieldIdInLinkedTable: 'fldName', result: {type: 'singleLineText'},
+				}, id: 'fldLookupText', name: 'Lookup Text',
+			},
+			{
+				type: 'multipleLookupValues', options: {
+					isValid: true, recordLinkFieldId: 'fldLinked', fieldIdInLinkedTable: 'fldNumber', result: {type: 'number', options: {precision: 0}},
+				}, id: 'fldLookupNumber', name: 'Lookup Number',
+			},
+			{
+				type: 'multipleLookupValues', options: {
+					isValid: true, recordLinkFieldId: 'fldLinked', fieldIdInLinkedTable: 'fldTags', result: {type: 'multipleSelects', options: {choices: []}},
+				}, id: 'fldLookupTags', name: 'Lookup Tags',
+			}],
 		views: [],
 	}],
 } satisfies {tables: BaseSchema};

--- a/src/jsTypeForAirtableType.test.ts
+++ b/src/jsTypeForAirtableType.test.ts
@@ -78,6 +78,19 @@ describe('jsTypeForAirtableType', () => {
 		expect(jsTypeForAirtableType(formula)).toBe('string | null');
 	});
 
+	it('handles multipleLookupValues fields as arrays', () => {
+		const lookupText = table.fields.find((f) => f.id === 'fldLookupText')!;
+		const lookupNumber = table.fields.find((f) => f.id === 'fldLookupNumber')!;
+		const lookupTags = table.fields.find((f) => f.id === 'fldLookupTags')!;
+
+		// Text lookup should return string[]
+		expect(jsTypeForAirtableType(lookupText)).toBe('string[]');
+		// Number lookup should return number[]
+		expect(jsTypeForAirtableType(lookupNumber)).toBe('number[]');
+		// Lookup of array type (multipleSelects) should return string[] (flattened)
+		expect(jsTypeForAirtableType(lookupTags)).toBe('string[]');
+	});
+
 	it('throws error for invalid formula field', () => {
 		const invalidFormula = {
 			type: 'formula',
@@ -86,5 +99,15 @@ describe('jsTypeForAirtableType', () => {
 		};
 
 		expect(() => jsTypeForAirtableType(invalidFormula as any)).toThrow('Invalid formula field (no options.result): invalid');
+	});
+
+	it('throws error for invalid multipleLookupValues field', () => {
+		const invalidLookup = {
+			type: 'multipleLookupValues',
+			id: 'invalidLookup',
+			options: {}, // Missing result property
+		};
+
+		expect(() => jsTypeForAirtableType(invalidLookup as any)).toThrow('Invalid multipleLookupValues field (no options.result): invalidLookup');
 	});
 });


### PR DESCRIPTION
## Summary

- Handle `multipleLookupValues` separately from `lookup`, `rollup`, and `formula` fields
- Return array types (e.g., `string[]`, `number[]`) instead of scalar types with null
- Strip nullability from inner type since an empty array represents no values
- Handle nested arrays by returning the flattened type (Airtable flattens lookup results)

Fixes #33